### PR TITLE
Handle the file dialog Cancel properly

### DIFF
--- a/lib/fdialog.js
+++ b/lib/fdialog.js
@@ -37,7 +37,7 @@ module.exports = FDialog;
  */
 
 FDialog.NoSelectedFile = function (message) {
-    this.name = 'NoSoelectedFile';
+    this.name = 'NoSelectedFile';
     this.message = message;
     this.stack = (new Error()).stack;
 };
@@ -65,7 +65,7 @@ FDialog.prototype._createElement = function () {
 
     if (this._options.type == 'save') {
 
-        var nwsaveas = window.document.createAttribute("nwsaveas");
+        var nwsaveas = this.window.document.createAttribute("nwsaveas");
 
         if (this._options.defaultSavePath) {
             nwsaveas.value = this._options.defaultSavePath;
@@ -76,12 +76,12 @@ FDialog.prototype._createElement = function () {
     } else if (this._options.type == 'directory') {
         // Future
         throw new Error("Not implemented");
-        /*var nwdirectory = window.document.createAttribute('nwdirectory');
+        /*var nwdirectory = this.window.document.createAttribute('nwdirectory');
         this.element.setAttributeNode(nwdirectory);*/
     }
 
     if (this._options.path) {
-        var nwworkingdir = window.document.createAttribute('nwworkingdir');
+        var nwworkingdir = this.window.document.createAttribute('nwworkingdir');
         nwworkingdir.value = this._options.path;
 
         this.element.setAttributeNode(nwworkingdir);
@@ -90,15 +90,22 @@ FDialog.prototype._createElement = function () {
 
     if (this._options.accept) {
         
-        var accept = window.document.createAttribute('accept');
+        var accept = this.window.document.createAttribute('accept');
         accept.value = this._options.accept.join(',');
 
         this.element.setAttributeNode(accept);
 
     }
 
-    this.element.addEventListener('change', function (ev) {
-        self.emit('element-change', ev, this.element);
+    // Get the reference to the nwjs window object (not the DOM window).
+    var gui = this.window.require('nw.gui');
+    var win = gui.Window.get();
+    // Handle the nwjs window focus event (triggered after the file selection dialog is closed).
+    win.on('focus', function () {
+        // Add a delay to handle the change after the selected file path is assigned to the element's value.
+        setTimeout(function () {
+            self.emit('element-change', /* ev = */ { target: self.element }, /* element = */ self.element);
+        }, 100);
     });
 
     return this.element;
@@ -139,7 +146,7 @@ FDialog.prototype.show = function (cb) {
     cb = cb || function () {};
 
     element.click();
-    cb (null, element);
+    cb(null, element);
 
 };
 
@@ -152,11 +159,11 @@ FDialog.prototype.getFilePath = function (cb) {
 
     self.once('element-change', function (ev, element) {
 
-        var filename = this.element.value;
+        var filename = self.element.value;
+
+        self.element = null;
 
         if (!filename) return cb(new FDialog.NoSelectedFile("No file selected") , null);
-
-        this.element = null;
 
         cb(null, filename);
 


### PR DESCRIPTION
- Fix #2 (The saveFile callback does not get called on Cancel in Mac OS X 10.9.2).
- Fix an inconsistency in usages of `window`.
- Fix a memory leak when no file is selected.
- Fix a typo in `NoSelectedFile` error `name`.
